### PR TITLE
Add documentation for `FuncView`

### DIFF
--- a/Sources/PlotUI/Bar.swift
+++ b/Sources/PlotUI/Bar.swift
@@ -29,7 +29,7 @@ import SwiftUI
 ///     )
 ///     .barWidth(20)
 /// }
-/// .viewport(bottom: 20)
+/// .tickInsets(bottom: 20)
 /// .contentDisposition(left: 0, right: 10)
 /// ```
 /// ![A bar view with 20-pixels wide bars](barview-barwidth.png)
@@ -44,7 +44,7 @@ import SwiftUI
 ///     .barWidth(20)
 ///     .barColor(.green)
 /// }
-/// .viewport(bottom: 20)
+/// .tickInsets(bottom: 20)
 /// .contentDisposition(left: 0, right: 10)
 /// ```
 /// ![A bar view with green 20-pixels wide bars](barview-barcolor.png)
@@ -61,7 +61,7 @@ import SwiftUI
 ///     .barColor(.green)
 ///     .barCornerRadius(10)
 /// }
-/// .viewport(bottom: 20)
+/// .tickInsets(bottom: 20)
 /// .contentDisposition(left: 0, right: 10)
 /// ```
 /// ![A bar view with green rounded 20-pixels wide bars](barview-barcornerradius.png)

--- a/Sources/PlotUI/Func.swift
+++ b/Sources/PlotUI/Func.swift
@@ -112,27 +112,36 @@ extension View {
     }
 }
 
+/// A view that represents plotting data.
 public protocol FuncView: View {
+    /// The content disposition of the data.
     var disposition: ContentDisposition { get }
 }
 
 /// A type-erased FuncView view.
+///
+/// An `AnyFuncView` allows changing the type of the `FuncView` used in a given view
+/// hierarchy. Whenever the type of view used with an `AnyFuncView` changes, the old
+/// hierarchy is destroyed and a new hierarchy is created for the new type.
 public struct AnyFuncView: FuncView {
-
+    /// The type of view representing the body of this view.
     public typealias Body = AnyView
 
     private var _disposition: ContentDisposition
     private var _view: AnyView
 
+    /// Creates an instance that type-erases `view`.
     public init<V: FuncView>(_ view: V) {
         self._view = AnyView(view)
         self._disposition = view.disposition
     }
 
+    /// The limits of the content.
     public var disposition: ContentDisposition {
         self._disposition
     }
 
+    /// The content and behavior of the view.
     public var body: AnyView {
         _view
     }


### PR DESCRIPTION
This patch adds documentation for `FuncView` and `AnyFuncView`.

Closes #28 